### PR TITLE
Revert to coffeescript 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - "4"
-  - "5"
-  - "7"
+  - "6"
   - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
+  - "7"
+  - "8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,9 +236,9 @@
       "dev": true
     },
     "coffeescript": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.1.tgz",
-      "integrity": "sha512-DNJmSPMyiz+OjWYyuDXNBcFutDjP2TS2owsZ8YvT65hA8c5IdHWIBqdA3Yf/XHoK23d/f1HqLjQbEJJZJoeV1w=="
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
     },
     "commander": {
       "version": "2.15.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/andersonshatch/hubot-beerbods/issues"
   },
   "dependencies": {
-    "coffeescript": "2.x"
+    "coffeescript": "1.x"
   },
   "peerDependencies": {
     "hubot": "2.x",


### PR DESCRIPTION
Hubot itself uses coffeescript 1 and node>=4, so match that.